### PR TITLE
use ofGetLastFrameTime for exact timing

### DIFF
--- a/AdvancedTween/src/AdvancedTweenApp.cpp
+++ b/AdvancedTween/src/AdvancedTweenApp.cpp
@@ -39,7 +39,7 @@ void AdvancedTweenApp::setup(){
 
 //--------------------------------------------------------------
 void AdvancedTweenApp::update(){
-    timeline.step(1/60.);
+    timeline.step(ofGetLastFrameTime());
 }
 
 //--------------------------------------------------------------

--- a/BasicAppendTween/src/BasicAppendTweenApp.cpp
+++ b/BasicAppendTween/src/BasicAppendTweenApp.cpp
@@ -12,7 +12,7 @@ void BasicAppendTweenApp::setup()
 
 //--------------------------------------------------------------
 void BasicAppendTweenApp::update(){
-    timeline().step(1/60.);
+    timeline().step(ofGetLastFrameTime());
 }
 
 //--------------------------------------------------------------


### PR DESCRIPTION
`ofGetLastFrameTime` is preferable to `1/60.` since framerate can change
