### PR TITLE
Add iterator include

### DIFF
--- a/libs/Choreograph/src/choreograph/Timeline.h
+++ b/libs/Choreograph/src/choreograph/Timeline.h
@@ -27,6 +27,7 @@
 
 #pragma once
 
+#include <iterator>
 #include "TimelineOptions.hpp"
 #include "detail/MakeUnique.hpp"
 


### PR DESCRIPTION
Needed to include the `iterator` library to get an openFrameworks project I'm working on using this addon to compile.

![image](https://user-images.githubusercontent.com/4695300/137065650-5df87d81-1d0b-4c6f-bb70-c4558b50bbfd.png)
